### PR TITLE
Fix: Google font not loading on mobile

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,3 +1,5 @@
+@import url("https://fonts.googleapis.com/css2?family=Martel+Sans:wght@200;300;400;600;700;800;900&display=swap");
+
 body {
   font-size: 16px;
   font-family: "Martel Sans", serif;


### PR DESCRIPTION
2nd attempt to fix Google Font not loading on mobile devices: Safari, Firefox Focus.